### PR TITLE
Fix TouchThroughView detection on Android

### DIFF
--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
@@ -65,7 +65,7 @@ public class TouchThroughWrapper extends ReactViewGroup implements ReactHitSlopV
 
             if (isTouchThroughView) {
                 Rect bounds = new Rect();
-                isTouchingTouchThroughView = child.getGlobalVisibleRect(bounds) ? bounds.contains(x, y) : false;
+                isTouchingTouchThroughView = child.getGlobalVisibleRect(bounds) && bounds.contains(x, y);
                 /*
                 int[] location = new int[2];
                 int[] thisLocation = new int[2];

--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
@@ -65,9 +65,7 @@ public class TouchThroughWrapper extends ReactViewGroup implements ReactHitSlopV
 
             if (isTouchThroughView) {
                 Rect bounds = new Rect();
-                child.getGlobalVisibleRect(bounds);
-
-                isTouchingTouchThroughView = bounds.contains(x, y);
+                isTouchingTouchThroughView = child.getGlobalVisibleRect(bounds) ? bounds.contains(x, y) : false;
                 /*
                 int[] location = new int[2];
                 int[] thisLocation = new int[2];


### PR DESCRIPTION
getGlobalVisibleRect returns a boolean that is false if the view is
completely clipped or translated out. By ignoring the result, there will
be some situations where the TouchThroughView is incorrectly detected.