### PR TITLE
Fixed regression of null check set activity listener 

### DIFF
--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
@@ -19,7 +19,7 @@ public class TouchThroughWrapper extends ReactViewGroup implements ReactHitSlopV
 
     public TouchThroughWrapper(ReactContext context) {
         super(context);
-        if (context != null) {
+        if (context == null) {
             return;
         }
         Activity activity = context.getCurrentActivity();

--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
@@ -19,7 +19,13 @@ public class TouchThroughWrapper extends ReactViewGroup implements ReactHitSlopV
 
     public TouchThroughWrapper(ReactContext context) {
         super(context);
+        if (context != null) {
+            return;
+        }
         Activity activity = context.getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
         if (activity instanceof TouchThroughTouchHandlerInterface) {
             TouchThroughTouchHandlerInterface handlerInterface = (TouchThroughTouchHandlerInterface) activity;
             handler = handlerInterface.getTouchThroughTouchHandler();

--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughWrapper.java
@@ -48,11 +48,15 @@ public class TouchThroughWrapper extends ReactViewGroup implements ReactHitSlopV
         }
     };
     public void addActivityListener() {
-        handler.addListener(listener);
+        if(handler != null) {
+            handler.addListener(listener);
+        }
     }
 
     public void removeActivityListener() {
-        handler.removeListener(listener);
+        if(handler != null) {
+            handler.removeListener(listener);
+        }
     }
 
     // Recursively find out if an absolute x/y position is hitting a child view and stop event


### PR DESCRIPTION
My previous PR caused a regression that resurfaced this issue: https://github.com/simonhoss/react-native-touch-through-view/issues/5